### PR TITLE
Type erasure of  DelegatingViewModel's binder

### DIFF
--- a/Example/MVVMKit/Base.lproj/Main.storyboard
+++ b/Example/MVVMKit/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9Uh-tC-1l8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9Uh-tC-1l8">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,10 +12,6 @@
         <scene sceneID="ufC-wZ-h7g">
             <objects>
                 <viewController storyboardIdentifier="RootViewController" id="vXZ-lx-hvc" customClass="RootViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
-                        <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -79,7 +76,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="Tly-Xa-lNN" firstAttribute="leading" secondItem="i1H-eM-hVV" secondAttribute="leading" id="9FU-M4-zis"/>
-                                    <constraint firstAttribute="trailing" secondItem="Tly-Xa-lNN" secondAttribute="trailing" constant="20" symbolic="YES" id="Lxx-s2-7Wc"/>
+                                    <constraint firstAttribute="trailing" secondItem="Tly-Xa-lNN" secondAttribute="trailing" id="Lxx-s2-7Wc"/>
                                     <constraint firstItem="Tly-Xa-lNN" firstAttribute="top" secondItem="i1H-eM-hVV" secondAttribute="top" id="VfS-IR-9R5"/>
                                     <constraint firstAttribute="bottom" secondItem="Tly-Xa-lNN" secondAttribute="bottom" id="co5-dm-Xeu"/>
                                     <constraint firstItem="Tly-Xa-lNN" firstAttribute="width" secondItem="JAp-kZ-H8c" secondAttribute="width" id="lva-bV-EVm"/>
@@ -90,11 +87,12 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="i1H-eM-hVV" secondAttribute="trailing" id="1Fm-IB-5Iv"/>
-                            <constraint firstItem="i1H-eM-hVV" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="9nS-2B-g6h"/>
+                            <constraint firstItem="m3L-cp-HKU" firstAttribute="trailing" secondItem="i1H-eM-hVV" secondAttribute="trailing" id="1Fm-IB-5Iv"/>
+                            <constraint firstItem="i1H-eM-hVV" firstAttribute="leading" secondItem="m3L-cp-HKU" secondAttribute="leading" id="9nS-2B-g6h"/>
                             <constraint firstAttribute="bottom" secondItem="i1H-eM-hVV" secondAttribute="bottom" id="Y64-Ld-97L"/>
-                            <constraint firstItem="i1H-eM-hVV" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" id="aN1-PJ-LHd"/>
+                            <constraint firstItem="i1H-eM-hVV" firstAttribute="top" secondItem="m3L-cp-HKU" secondAttribute="top" id="aN1-PJ-LHd"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="m3L-cp-HKU"/>
                     </view>
                     <navigationItem key="navigationItem" id="z8b-Hv-O4w"/>
                 </viewController>
@@ -106,10 +104,6 @@
         <scene sceneID="rmr-hp-tjw">
             <objects>
                 <viewController storyboardIdentifier="BasicViewController" id="6iJ-9p-xco" customClass="BasicViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="gql-F4-5al"/>
-                        <viewControllerLayoutGuide type="bottom" id="lIj-2X-H6a"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="f3r-v7-FcU">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -143,9 +137,10 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="fpR-Ip-diX" firstAttribute="centerX" secondItem="f3r-v7-FcU" secondAttribute="centerX" id="P1S-N2-Bpn"/>
+                            <constraint firstItem="fpR-Ip-diX" firstAttribute="centerX" secondItem="a0H-gM-LI5" secondAttribute="centerX" id="P1S-N2-Bpn"/>
                             <constraint firstItem="fpR-Ip-diX" firstAttribute="centerY" secondItem="f3r-v7-FcU" secondAttribute="centerY" id="gs8-rl-niN"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="a0H-gM-LI5"/>
                     </view>
                     <connections>
                         <outlet property="label" destination="NcF-2a-UdD" id="oqC-Sn-LAW"/>
@@ -161,10 +156,6 @@
         <scene sceneID="ykf-wK-WQJ">
             <objects>
                 <viewController storyboardIdentifier="ColorsViewController" id="o9a-vj-Ehw" customClass="ColorsViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="4wl-IB-DZc"/>
-                        <viewControllerLayoutGuide type="bottom" id="0Ns-WQ-RjA"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gDQ-Lk-eDl">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -247,11 +238,12 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="q8V-WB-01f" secondAttribute="trailing" id="Apv-dT-94k"/>
-                            <constraint firstItem="q8V-WB-01f" firstAttribute="leading" secondItem="gDQ-Lk-eDl" secondAttribute="leading" id="Azz-BG-uLv"/>
+                            <constraint firstItem="K2q-JQ-fvh" firstAttribute="trailing" secondItem="q8V-WB-01f" secondAttribute="trailing" id="Apv-dT-94k"/>
+                            <constraint firstItem="q8V-WB-01f" firstAttribute="leading" secondItem="K2q-JQ-fvh" secondAttribute="leading" id="Azz-BG-uLv"/>
                             <constraint firstAttribute="bottom" secondItem="q8V-WB-01f" secondAttribute="bottom" id="XXk-z3-DBS"/>
-                            <constraint firstItem="q8V-WB-01f" firstAttribute="top" secondItem="4wl-IB-DZc" secondAttribute="bottom" id="iPm-5G-RoC"/>
+                            <constraint firstItem="q8V-WB-01f" firstAttribute="top" secondItem="K2q-JQ-fvh" secondAttribute="top" id="iPm-5G-RoC"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="K2q-JQ-fvh"/>
                     </view>
                     <navigationItem key="navigationItem" id="p9f-hf-2q9"/>
                     <connections>
@@ -267,10 +259,6 @@
         <scene sceneID="2ho-6X-X6h">
             <objects>
                 <viewController storyboardIdentifier="DiffableCollectionViewController" id="Yhn-F8-r1v" customClass="DiffableCollectionViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="Luo-ag-XxB"/>
-                        <viewControllerLayoutGuide type="bottom" id="Rjz-LS-ftm"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="1n7-gR-CZW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -296,14 +284,15 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="0Lr-KN-mjz" firstAttribute="top" secondItem="Luo-ag-XxB" secondAttribute="bottom" id="17v-88-rfT"/>
-                            <constraint firstAttribute="trailing" secondItem="thk-ef-TXc" secondAttribute="trailing" id="Ccg-3a-yFs"/>
-                            <constraint firstItem="0Lr-KN-mjz" firstAttribute="leading" secondItem="1n7-gR-CZW" secondAttribute="leading" id="Vl2-kA-R1O"/>
+                            <constraint firstItem="0Lr-KN-mjz" firstAttribute="top" secondItem="x7w-nF-fva" secondAttribute="top" id="17v-88-rfT"/>
+                            <constraint firstItem="x7w-nF-fva" firstAttribute="trailing" secondItem="thk-ef-TXc" secondAttribute="trailing" id="Ccg-3a-yFs"/>
+                            <constraint firstItem="0Lr-KN-mjz" firstAttribute="leading" secondItem="x7w-nF-fva" secondAttribute="leading" id="Vl2-kA-R1O"/>
                             <constraint firstAttribute="bottom" secondItem="thk-ef-TXc" secondAttribute="bottom" id="Y2X-Io-Wgg"/>
-                            <constraint firstAttribute="trailing" secondItem="0Lr-KN-mjz" secondAttribute="trailing" id="YRO-Nc-fUS"/>
+                            <constraint firstItem="x7w-nF-fva" firstAttribute="trailing" secondItem="0Lr-KN-mjz" secondAttribute="trailing" id="YRO-Nc-fUS"/>
                             <constraint firstItem="thk-ef-TXc" firstAttribute="top" secondItem="0Lr-KN-mjz" secondAttribute="bottom" id="keW-ms-G2W"/>
-                            <constraint firstItem="thk-ef-TXc" firstAttribute="leading" secondItem="1n7-gR-CZW" secondAttribute="leading" id="pRM-f0-mHi"/>
+                            <constraint firstItem="thk-ef-TXc" firstAttribute="leading" secondItem="x7w-nF-fva" secondAttribute="leading" id="pRM-f0-mHi"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="x7w-nF-fva"/>
                     </view>
                     <connections>
                         <outlet property="collectionView" destination="thk-ef-TXc" id="6V7-f5-vca"/>
@@ -317,10 +306,6 @@
         <scene sceneID="9i0-gA-VO0">
             <objects>
                 <viewController storyboardIdentifier="DiffableTableViewController" id="Uhm-SO-gTz" customClass="DiffableTableViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="SCD-HZ-RQS"/>
-                        <viewControllerLayoutGuide type="bottom" id="d6K-XJ-Gly"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="d12-H3-G4h">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -366,14 +351,15 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="eri-8n-fNx" firstAttribute="leading" secondItem="d12-H3-G4h" secondAttribute="leading" id="3L4-S6-0Hv"/>
+                            <constraint firstItem="eri-8n-fNx" firstAttribute="leading" secondItem="fnJ-ej-X1k" secondAttribute="leading" id="3L4-S6-0Hv"/>
                             <constraint firstAttribute="bottom" secondItem="XlJ-bM-Spm" secondAttribute="bottom" id="AUm-YA-blc"/>
                             <constraint firstItem="XlJ-bM-Spm" firstAttribute="top" secondItem="eri-8n-fNx" secondAttribute="bottom" id="I5r-hd-Uce"/>
-                            <constraint firstAttribute="trailing" secondItem="eri-8n-fNx" secondAttribute="trailing" id="OUY-I7-xT2"/>
-                            <constraint firstItem="XlJ-bM-Spm" firstAttribute="leading" secondItem="d12-H3-G4h" secondAttribute="leading" id="Xz1-S0-NxD"/>
-                            <constraint firstAttribute="trailing" secondItem="XlJ-bM-Spm" secondAttribute="trailing" id="cTd-qa-92U"/>
-                            <constraint firstItem="eri-8n-fNx" firstAttribute="top" secondItem="SCD-HZ-RQS" secondAttribute="bottom" id="vyB-TW-Eeg"/>
+                            <constraint firstItem="fnJ-ej-X1k" firstAttribute="trailing" secondItem="eri-8n-fNx" secondAttribute="trailing" id="OUY-I7-xT2"/>
+                            <constraint firstItem="XlJ-bM-Spm" firstAttribute="leading" secondItem="fnJ-ej-X1k" secondAttribute="leading" id="Xz1-S0-NxD"/>
+                            <constraint firstItem="fnJ-ej-X1k" firstAttribute="trailing" secondItem="XlJ-bM-Spm" secondAttribute="trailing" id="cTd-qa-92U"/>
+                            <constraint firstItem="eri-8n-fNx" firstAttribute="top" secondItem="fnJ-ej-X1k" secondAttribute="top" id="vyB-TW-Eeg"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="fnJ-ej-X1k"/>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="XlJ-bM-Spm" id="A00-LT-IKM"/>
@@ -405,10 +391,6 @@
         <scene sceneID="4Km-kQ-MDw">
             <objects>
                 <viewController storyboardIdentifier="GiphyMasterDetailViewController" id="guq-Ni-R1q" customClass="GiphyMasterDetailViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="BHz-uR-sxd"/>
-                        <viewControllerLayoutGuide type="bottom" id="6B2-C1-MLs"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="yeo-mV-3yW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -452,11 +434,12 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="eiB-Rh-6Jh" firstAttribute="leading" secondItem="yeo-mV-3yW" secondAttribute="leading" id="HwK-vy-f48"/>
-                            <constraint firstItem="6B2-C1-MLs" firstAttribute="top" secondItem="eiB-Rh-6Jh" secondAttribute="bottom" id="MKT-zd-jnh"/>
-                            <constraint firstAttribute="trailing" secondItem="eiB-Rh-6Jh" secondAttribute="trailing" id="NHh-dN-kYk"/>
-                            <constraint firstItem="eiB-Rh-6Jh" firstAttribute="top" secondItem="BHz-uR-sxd" secondAttribute="bottom" id="uH2-PW-EdJ"/>
+                            <constraint firstItem="eiB-Rh-6Jh" firstAttribute="leading" secondItem="G1d-rb-lKJ" secondAttribute="leading" id="HwK-vy-f48"/>
+                            <constraint firstItem="G1d-rb-lKJ" firstAttribute="bottom" secondItem="eiB-Rh-6Jh" secondAttribute="bottom" id="MKT-zd-jnh"/>
+                            <constraint firstItem="G1d-rb-lKJ" firstAttribute="trailing" secondItem="eiB-Rh-6Jh" secondAttribute="trailing" id="NHh-dN-kYk"/>
+                            <constraint firstItem="eiB-Rh-6Jh" firstAttribute="top" secondItem="G1d-rb-lKJ" secondAttribute="top" id="uH2-PW-EdJ"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="G1d-rb-lKJ"/>
                     </view>
                     <connections>
                         <outlet property="activityIndicatorView" destination="8v8-F7-TdO" id="zCE-W4-ogQ"/>
@@ -472,10 +455,6 @@
         <scene sceneID="kJu-vM-omC">
             <objects>
                 <viewController storyboardIdentifier="GiphyViewController" id="xJF-Ja-Hmh" customClass="GiphyViewController" customModule="MVVMKit_Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="UhJ-Iw-KBk"/>
-                        <viewControllerLayoutGuide type="bottom" id="98X-nQ-frI"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="sSS-5p-wCe">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -552,15 +531,16 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="LyQ-Fo-JbP" secondAttribute="trailing" id="0pg-Ro-thA"/>
+                            <constraint firstItem="3SK-IG-6cu" firstAttribute="trailing" secondItem="LyQ-Fo-JbP" secondAttribute="trailing" id="0pg-Ro-thA"/>
                             <constraint firstItem="hOR-l2-vWr" firstAttribute="centerY" secondItem="m7Z-rf-Wbe" secondAttribute="centerY" id="Axy-YH-dSy"/>
                             <constraint firstItem="uaF-1n-gve" firstAttribute="centerY" secondItem="m7Z-rf-Wbe" secondAttribute="centerY" id="DaY-Yq-J0k"/>
                             <constraint firstAttribute="bottom" secondItem="LyQ-Fo-JbP" secondAttribute="bottom" id="Lwh-0N-L3r"/>
-                            <constraint firstItem="LyQ-Fo-JbP" firstAttribute="top" secondItem="UhJ-Iw-KBk" secondAttribute="bottom" id="PXS-nn-AAf"/>
+                            <constraint firstItem="LyQ-Fo-JbP" firstAttribute="top" secondItem="3SK-IG-6cu" secondAttribute="top" id="PXS-nn-AAf"/>
                             <constraint firstItem="hOR-l2-vWr" firstAttribute="centerX" secondItem="m7Z-rf-Wbe" secondAttribute="centerX" id="qu9-pO-HhG"/>
                             <constraint firstItem="uaF-1n-gve" firstAttribute="centerX" secondItem="m7Z-rf-Wbe" secondAttribute="centerX" id="xkh-QU-2Ti"/>
-                            <constraint firstItem="LyQ-Fo-JbP" firstAttribute="leading" secondItem="sSS-5p-wCe" secondAttribute="leading" id="zo3-Cb-P4Z"/>
+                            <constraint firstItem="LyQ-Fo-JbP" firstAttribute="leading" secondItem="3SK-IG-6cu" secondAttribute="leading" id="zo3-Cb-P4Z"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="3SK-IG-6cu"/>
                     </view>
                     <connections>
                         <outlet property="activityIndicatorView" destination="uaF-1n-gve" id="wa6-Gs-kLI"/>

--- a/Example/MVVMKit/BasicViewController.swift
+++ b/Example/MVVMKit/BasicViewController.swift
@@ -32,7 +32,7 @@ class BasicViewController: UIViewController, ViewModelOwner {
     typealias CustomViewModel = BasicViewModel
     
     var viewModel: BasicViewModel? {
-        didSet { viewModel?.binder = self }
+        didSet { viewModel?.binder = AnyBinder(self) }
     }
     
     override func viewDidLoad() {

--- a/Example/MVVMKit/BasicViewModel.swift
+++ b/Example/MVVMKit/BasicViewModel.swift
@@ -24,25 +24,25 @@
 
 import MVVMKit
 
-class BasicViewModel: BaseDelegatingViewModel {
-    var weakBinder: WeakReference<Binder>?
-    
-    struct Model {
-        var value: Float
-        var state: State
-    }
+struct BasicModel {
+    var value: Float
+    var state: State
     
     enum State {
         case on
         case off
     }
+}
+
+class BasicViewModel: BaseDelegatingViewModel {
+    var binder: AnyBinder<BasicViewModel>?
     
-    init(model: Model) {
+    init(model: BasicModel) {
         self.model = model
     }
     
     // MARK: Model
-    private var model: Model {
+    private var model: BasicModel {
         didSet { binder?.bind(viewModel: self) }
     }
     
@@ -96,7 +96,7 @@ class BasicViewModel: BaseDelegatingViewModel {
         model.value = value
     }
     
-    func set(state: State) {
+    func set(state: BasicModel.State) {
         model.state = state
     }
     

--- a/Example/MVVMKit/ColorsViewModel.swift
+++ b/Example/MVVMKit/ColorsViewModel.swift
@@ -24,26 +24,27 @@
 
 import MVVMKit
 
+struct ColorsModel {
+    var colors: [Color]
+    var selectedColor: Color?
+}
+
 struct Color {
     let name: String
     let values: (r: CGFloat, g: CGFloat, b: CGFloat)
 }
 
 class ColorsViewModel: TableViewViewModel {
-    var weakBinder: WeakReference<TableViewBinder>?
+    var binder: AnyTableViewBinder<ColorsViewModel>?
+    
     var sections: [SectionViewModel] = []
     private var state: State = .normal
     
-    struct Model {
-        var colors: [Color]
-        var selectedColor: Color?
-    }
-    
-    private var model: Model {
+    private var model: ColorsModel {
         didSet { updateSections() }
     }
     
-    init(model: Model) {
+    init(model: ColorsModel) {
         sections = []
         self.model = model
         updateSections()
@@ -58,19 +59,19 @@ class ColorsViewModel: TableViewViewModel {
     
     func didSelectColor(at index: Int) {
         model.selectedColor = model.colors[index]
-        binder?.viewModel(self, didChange: nil)
+        binder?.bind(viewModel: self, update: nil)
     }
     
     func invertColor(at index: Int) {
         model.colors[index] = model.colors[index].inverted
-        binder?.viewModel(self, didChange: .reloadRows([IndexPath(row: index, section: 0)], with: .automatic))
+        binder?.bind(viewModel: self, update: .reloadRows([IndexPath(row: index, section: 0)], with: .automatic))
     }
     
     func setEditMode(enabled: Bool) {
         state = enabled ? .edit : .normal
         model.selectedColor = nil
         updateSections()
-        binder?.viewModel(self, didChange: .reloadData)
+        binder?.bind(viewModel: self, update: .reloadData)
     }
     
     // MARK - Read only prorperties

--- a/Example/MVVMKit/GiphyMasterDetailViewController.swift
+++ b/Example/MVVMKit/GiphyMasterDetailViewController.swift
@@ -31,7 +31,7 @@ class GiphyMasterDetailViewController: UIViewController, ViewModelOwner {
     @IBOutlet private weak var containerView: UIView!
     
     var viewModel: GiphyMasterDetailViewModel? {
-        didSet { viewModel?.binder = self }
+        didSet { viewModel?.binder = AnyBinder(self) }
     }
     
     override func viewDidLoad() {

--- a/Example/MVVMKit/GiphyMasterDetailViewModel.swift
+++ b/Example/MVVMKit/GiphyMasterDetailViewModel.swift
@@ -26,8 +26,8 @@ import MVVMKit
 
 class GiphyMasterDetailViewModel: CoordinatedBaseDelegatingViewModel {
     typealias CoordinatorType = GiphyMasterDetailCoordinator
+    var binder: AnyBinder<GiphyMasterDetailViewModel>?
     var coordinator: GiphyMasterDetailCoordinator
-    var weakBinder: WeakReference<Binder>?
     
     struct Model {
         var selectedGif: GiphyResult? = nil

--- a/Example/MVVMKit/GiphyViewModel.swift
+++ b/Example/MVVMKit/GiphyViewModel.swift
@@ -29,7 +29,7 @@ protocol GiphyViewModelDelegate: class {
 }
 
 class GiphyViewModel: CollectionViewViewModel {
-    var weakBinder: WeakReference<CollectionViewBinder>?
+    var binder: AnyCollectionViewBinder<GiphyViewModel>?
     weak var delegate: GiphyViewModelDelegate?
     var sections: [SectionViewModel] = []
     
@@ -81,12 +81,12 @@ class GiphyViewModel: CollectionViewViewModel {
     private func startFetch() {
         model.isFetching = true
         model.gifs = []
-        binder?.viewModel(self, didChange: .reloadData)
+        binder?.bind(viewModel: self, update: .reloadData)
     }
     
     private func endFetch() {
         model.isFetching = false
-        self.binder?.viewModel(self, didChange: .reloadData)
+        self.binder?.bind(viewModel: self, update: .reloadData)
     }
     
     private func updateSections() {

--- a/Example/MVVMKit/RootCoordinator.swift
+++ b/Example/MVVMKit/RootCoordinator.swift
@@ -31,13 +31,13 @@ class RootCoordinator: Coordinator {
         sourceViewController = viewController
     }
     
-    func didSelectBasicViewController(model: BasicViewModel.Model) {
+    func didSelectBasicViewController(model: BasicModel) {
         let viewController = BasicViewController.instantiate(storyboardName: "Main")
         viewController.viewModel = BasicViewModel(model: model)
         sourceViewController?.show(viewController, sender: nil)
     }
     
-    func didSelectTableViewController(model: ColorsViewModel.Model) {
+    func didSelectTableViewController(model: ColorsModel) {
         let viewController = ColorsViewController.instantiate(storyboardName: "Main")
         viewController.viewModel = ColorsViewModel(model: model)
         sourceViewController?.show(viewController, sender: nil)

--- a/Example/MVVMKit/RootViewModel.swift
+++ b/Example/MVVMKit/RootViewModel.swift
@@ -26,7 +26,7 @@ import MVVMKit
 
 class RootViewModel: CoordinatedBaseDelegatingViewModel {
     typealias CoordinatorType = RootCoordinator
-    var weakBinder: WeakReference<Binder>?
+    var binder: AnyBinder<RootViewModel>?
     var coordinator: RootCoordinator
     
     private let model: RootModel

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,12 +15,16 @@
 			dependencies = (
 			);
 			name = SwiftLint;
+			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
 		0645A86BEF554EF9F7DA45E96A4F9EF5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8DA2D971384248B54D935BB7012520 /* ViewModel.swift */; };
 		22D295641C3149CDC03002067A22ED1B /* CollectionViewViewModelOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1EC3B958338864EE3D31D56D19FD3E /* CollectionViewViewModelOwner.swift */; };
+		2DB067D923B0B30C0051C480 /* AnyBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB067D823B0B30C0051C480 /* AnyBinder.swift */; };
+		2DB067DB23B0B3710051C480 /* AnyTableViewBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB067DA23B0B3710051C480 /* AnyTableViewBinder.swift */; };
+		2DB067DD23B0B37A0051C480 /* AnyCollectionViewBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB067DC23B0B37A0051C480 /* AnyCollectionViewBinder.swift */; };
 		3452847D3867CC05CD6A711326AA8605 /* DelegatingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C51CC07C3359496F2EBF8A6BE1E748 /* DelegatingViewModel.swift */; };
 		34F5AF300B0DA0D0A9BDD88446CE7280 /* DispatchQueue+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B772E0548960209B1B44B8162D835D28 /* DispatchQueue+.swift */; };
 		35A8AE5B3058E690B8F63E7EA2537063 /* Binder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB6ECC188BFBD67C1E4A5DADD022A34 /* Binder.swift */; };
@@ -73,16 +77,19 @@
 /* Begin PBXFileReference section */
 		011952ABF11D576CB381AD3D2E1F4A98 /* TableViewViewModelOwner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewViewModelOwner.swift; sourceTree = "<group>"; };
 		05D40532AD87A40F07A69E3A37231880 /* MVVMKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MVVMKit.xcconfig; sourceTree = "<group>"; };
-		06D8CB0E6C970332F27AD2B497A307DB /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		1083D3BCBF6F9E736E18C115AF5C0DA5 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		06D8CB0E6C970332F27AD2B497A307DB /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		1083D3BCBF6F9E736E18C115AF5C0DA5 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		10C51CC07C3359496F2EBF8A6BE1E748 /* DelegatingViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DelegatingViewModel.swift; sourceTree = "<group>"; };
 		147C03E18C3BB63934D5FBCB710735B4 /* DiffableCollectionViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiffableCollectionViewViewModel.swift; sourceTree = "<group>"; };
 		175FFE43CDB446D76CCB6F19F73C155B /* CoordinatedReactiveViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoordinatedReactiveViewModel.swift; sourceTree = "<group>"; };
 		176DEFE429E6F53F7DC1C6FB713B4830 /* MVVMKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = MVVMKit.modulemap; sourceTree = "<group>"; };
 		1847DEBB8C8E5C231BF19E145101858C /* MVVMKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "MVVMKit-dummy.m"; sourceTree = "<group>"; };
-		267EEE90A5A3EEB674F0A626E92A5382 /* MVVMKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = MVVMKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		267EEE90A5A3EEB674F0A626E92A5382 /* MVVMKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = MVVMKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		27189C6457CC3652BA8F04FA0D59628F /* Pods-MVVMKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-MVVMKit_Example-frameworks.sh"; sourceTree = "<group>"; };
 		272C385A3FA2B20805610BDC8B19D525 /* TableViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewViewModel.swift; sourceTree = "<group>"; };
+		2DB067D823B0B30C0051C480 /* AnyBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyBinder.swift; sourceTree = "<group>"; };
+		2DB067DA23B0B3710051C480 /* AnyTableViewBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTableViewBinder.swift; sourceTree = "<group>"; };
+		2DB067DC23B0B37A0051C480 /* AnyCollectionViewBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCollectionViewBinder.swift; sourceTree = "<group>"; };
 		3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		375A64B1BC7EA629A6F144E869B8ED4F /* Coordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		37F7FB9753C21BDE3DCD1213C3F51DED /* DiffableTableViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiffableTableViewViewModel.swift; sourceTree = "<group>"; };
@@ -93,18 +100,18 @@
 		40361FED34F487498CA1F1215B2AF7C3 /* SectionViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SectionViewModel.swift; sourceTree = "<group>"; };
 		4162C389C8C1F73F038ACCCFA9DF234D /* Pods-MVVMKit_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MVVMKit_Example-Info.plist"; sourceTree = "<group>"; };
 		4BB6ECC188BFBD67C1E4A5DADD022A34 /* Binder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Binder.swift; sourceTree = "<group>"; };
-		59C249E899BE4FFEA0819887040457DB /* MVVMKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MVVMKit.framework; path = MVVMKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		59C249E899BE4FFEA0819887040457DB /* MVVMKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MVVMKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6389A4C7305E28A6573AB548CB77B096 /* CoordinatorOwner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoordinatorOwner.swift; sourceTree = "<group>"; };
 		66F37C89F5632B99C298B5AF104C2028 /* Pods-MVVMKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MVVMKit_Example.release.xcconfig"; sourceTree = "<group>"; };
 		67525D2596813CB3F93F21EBDD13FE6C /* MVVMDiffableCollectionViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MVVMDiffableCollectionViewController.swift; sourceTree = "<group>"; };
 		6CC444A3857539A077C2ABF3C6C8F0DA /* ViewModelOwner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelOwner.swift; sourceTree = "<group>"; };
 		70E48ACCB14E352DA16DB8E94A9BAA82 /* MVVMTableViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MVVMTableViewController.swift; sourceTree = "<group>"; };
 		779E8C9DD8799681F0D632FDA8791794 /* CollectionViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionViewViewModel.swift; sourceTree = "<group>"; };
-		7A7C5A94AB579D03E2C364021E109ED2 /* Pods_MVVMKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_MVVMKit_Example.framework; path = "Pods-MVVMKit_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A7C5A94AB579D03E2C364021E109ED2 /* Pods_MVVMKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MVVMKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		847AB103D6D853A09993C1239B3BE21A /* BaseDelegatingViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BaseDelegatingViewModel.swift; sourceTree = "<group>"; };
 		89F85ACF3D78B39506B75103B4694B36 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
 		9A0124F2A452B2806AE955FD728A2E56 /* Pods-MVVMKit_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-MVVMKit_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A3778C6553845886F79080FDF8BB2AF6 /* WeakReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeakReference.swift; sourceTree = "<group>"; };
 		B5E4D054491261C6049438641F307A2A /* MVVMKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MVVMKit-prefix.pch"; sourceTree = "<group>"; };
 		B772E0548960209B1B44B8162D835D28 /* DispatchQueue+.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+.swift"; sourceTree = "<group>"; };
@@ -172,6 +179,9 @@
 		5806AEBC53FEBABC30F147DEAD389D5C /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				2DB067D823B0B30C0051C480 /* AnyBinder.swift */,
+				2DB067DC23B0B37A0051C480 /* AnyCollectionViewBinder.swift */,
+				2DB067DA23B0B3710051C480 /* AnyTableViewBinder.swift */,
 				A3778C6553845886F79080FDF8BB2AF6 /* WeakReference.swift */,
 			);
 			name = Utils;
@@ -205,7 +215,6 @@
 				011952ABF11D576CB381AD3D2E1F4A98 /* TableViewViewModelOwner.swift */,
 				D635BEF581083C3034CBC3CD8714700E /* Container View Models */,
 			);
-			name = Delegate;
 			path = Delegate;
 			sourceTree = "<group>";
 		};
@@ -235,7 +244,6 @@
 			children = (
 				EEA599FE5C15138FF0981CCFB01E55AA /* Support Files */,
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -270,7 +278,6 @@
 				E9CA93F98D0395FE918EFF2C2A4BB782 /* ReusableViewViewModelAdapter.swift */,
 				BC8DBCCE1F11CBAE1A88C1312375E75D /* SnapshotUpdate.swift */,
 			);
-			name = "Diffable Container View Models";
 			path = "Diffable Container View Models";
 			sourceTree = "<group>";
 		};
@@ -323,7 +330,6 @@
 				40361FED34F487498CA1F1215B2AF7C3 /* SectionViewModel.swift */,
 				272C385A3FA2B20805610BDC8B19D525 /* TableViewViewModel.swift */,
 			);
-			name = "Container View Models";
 			path = "Container View Models";
 			sourceTree = "<group>";
 		};
@@ -334,7 +340,6 @@
 				76DC03A518E82716386A98A8E9F8CD29 /* Delegate */,
 				C68D9203AED6073C65D3434F5A6CA107 /* Diffable Container View Models */,
 			);
-			name = "View Model";
 			path = "View Model";
 			sourceTree = "<group>";
 		};
@@ -473,11 +478,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B72C9768931A1008DCE15DDD3D308AB0 /* BaseDelegatingViewModel.swift in Sources */,
+				2DB067DB23B0B3710051C480 /* AnyTableViewBinder.swift in Sources */,
 				35A8AE5B3058E690B8F63E7EA2537063 /* Binder.swift in Sources */,
 				66637A5E367A86F184CC1C701B1DB284 /* CollectionViewViewModel.swift in Sources */,
 				22D295641C3149CDC03002067A22ED1B /* CollectionViewViewModelOwner.swift in Sources */,
 				B1F0BB19477D3214F86B4E8B7D789ECC /* CoordinatedDelegatingViewModel.swift in Sources */,
 				7352ED1EB47F7CEAF6D7FBE3E95EE4DD /* CoordinatedReactiveViewModel.swift in Sources */,
+				2DB067DD23B0B37A0051C480 /* AnyCollectionViewBinder.swift in Sources */,
+				2DB067D923B0B30C0051C480 /* AnyBinder.swift in Sources */,
 				46CFA6AC77CBBB6D3A1FE715469EA455 /* Coordinator.swift in Sources */,
 				B0589F08382566F8CCBFB7096CB7ED36 /* CoordinatorOwner.swift in Sources */,
 				3452847D3867CC05CD6A711326AA8605 /* DelegatingViewModel.swift in Sources */,
@@ -595,8 +603,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/MVVMKit/Protocols/CoordinatorOwner.swift
+++ b/MVVMKit/Protocols/CoordinatorOwner.swift
@@ -40,7 +40,7 @@ public class DefaultCoordinator: Coordinator {
     
     public var weakSourceViewController: WeakReference<UIViewController>?
     
-    init(sourceViewController: ViewController) {
+    public init(sourceViewController: ViewController) {
         self.sourceViewController = sourceViewController
     }
 }

--- a/MVVMKit/Protocols/View Model/Delegate/BaseDelegatingViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/BaseDelegatingViewModel.swift
@@ -27,4 +27,4 @@
  If yor view controller manages a view owning cells (e.g. a table view) consider to use
  `TableViewViewModel` or `CollectionViewViewModel`
  */
-public protocol BaseDelegatingViewModel: DelegatingViewModel where BinderType == Binder { }
+public protocol BaseDelegatingViewModel: DelegatingViewModel where BinderType == AnyBinder<Self> { }

--- a/MVVMKit/Protocols/View Model/Delegate/CollectionViewViewModelOwner.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/CollectionViewViewModelOwner.swift
@@ -28,6 +28,6 @@ import UIKit
  A protocol describing the requirements of the owner of a collection view.
  Tipically the `CollectionViewViewModelOwner` is a `UIViewController`
  */
-public protocol CollectionViewViewModelOwner: ViewModelOwner, CollectionViewBinder where CustomViewModel: CollectionViewViewModel {
+public protocol CollectionViewViewModelOwner: ViewModelOwner, CollectionViewBinder {
     var collectionView: UICollectionView! { get }
 }

--- a/MVVMKit/Protocols/View Model/Delegate/Container View Models/CollectionViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/Container View Models/CollectionViewViewModel.swift
@@ -28,15 +28,15 @@ import UIKit
 /**
  The view model for a UICollectionView
  */
-public protocol CollectionViewViewModel: DelegatingViewModel where BinderType == CollectionViewBinder {
+public protocol CollectionViewViewModel: DelegatingViewModel where BinderType == AnyCollectionViewBinder<Self> {
     var sections: [SectionViewModel] { get }
 }
 
 /**
  A `CollectionViewBinder` is responsible to bind the view models of reusable view (cells, headers, footers).
  */
-public protocol CollectionViewBinder: Binder {
-    func viewModel(_ viewModel: ViewModel, didChange viewChange: CollectionViewUpdate?)
+public protocol CollectionViewBinder: CustomBinder where CustomViewModel: CollectionViewViewModel {
+    func bind(viewModel: CustomViewModel, update: CollectionViewUpdate?)
 }
 
 /// An enum describing what should be updated inside a collection view
@@ -54,10 +54,10 @@ public enum CollectionViewUpdate {
 }
 
 public extension CollectionViewBinder where Self: CollectionViewViewModelOwner {
-    func viewModel(_ viewModel: ViewModel, didChange viewChange: CollectionViewUpdate?) {
+    func bind(viewModel: CustomViewModel, update: CollectionViewUpdate?) {
         defer { bind(viewModel: viewModel) }
         
-        guard let change = viewChange else {
+        guard let change = update else {
             return
         }
         

--- a/MVVMKit/Protocols/View Model/Delegate/Container View Models/TableViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/Container View Models/TableViewViewModel.swift
@@ -28,15 +28,15 @@ import UIKit
 /**
  The view model for a UITableView
  */
-public protocol TableViewViewModel: DelegatingViewModel where BinderType == TableViewBinder {
+public protocol TableViewViewModel: DelegatingViewModel where BinderType == AnyTableViewBinder<Self> {
     var sections: [SectionViewModel] { get }
 }
 
 /**
  A `TableViewBinder` is responsible to bind the view models of reusable view (cells, headers, footers).
  */
-public protocol TableViewBinder: Binder {
-    func viewModel(_ viewModel: ViewModel, didChange viewChange: TableViewUpdate?)
+public protocol TableViewBinder: CustomBinder where CustomViewModel: TableViewViewModel {
+    func bind(viewModel: CustomViewModel, update: TableViewUpdate?)
 }
 
 /// An enum describing what should be updated inside a table view
@@ -54,10 +54,10 @@ public enum TableViewUpdate {
 }
 
 public extension TableViewBinder where Self: TableViewViewModelOwner {
-    func viewModel(_ viewModel: ViewModel, didChange viewChange: TableViewUpdate?) {
+    func bind(viewModel: CustomViewModel, update: TableViewUpdate?) {
         defer { bind(viewModel: viewModel) }
         
-        guard let change = viewChange else {
+        guard let change = update else {
             return
         }
         

--- a/MVVMKit/Protocols/View Model/Delegate/DelegatingViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/DelegatingViewModel.swift
@@ -26,15 +26,7 @@
  A special kind of view model that can own subviews view models
  */
 public protocol DelegatingViewModel: ReferenceViewModel {
-    associatedtype BinderType
-    /// The weak reference to the binder of the view model
-    var weakBinder: WeakReference<BinderType>? { get set }
-}
-
-public extension DelegatingViewModel {
-    // A convenience property to get and set the binder
-    var binder: BinderType? {
-        get { return weakBinder?.object }
-        set { weakBinder = WeakReference(newValue) }
-    }
+    associatedtype BinderType: CustomBinder
+    /// The reference to the binder of the view model
+    var binder: BinderType? { get set }
 }

--- a/MVVMKit/Protocols/View Model/Delegate/TableViewViewModelOwner.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/TableViewViewModelOwner.swift
@@ -28,6 +28,6 @@ import UIKit
  A protocol describing the requirements of the owner of a table view.
  Tipically the `TableViewViewModelOwner` is a `UIViewController`
  */
-public protocol TableViewViewModelOwner: ViewModelOwner, TableViewBinder where CustomViewModel: TableViewViewModel {
+public protocol TableViewViewModelOwner: ViewModelOwner, TableViewBinder {
     var tableView: UITableView! { get }
 }

--- a/MVVMKit/Utils/AnyCollectionViewBinder.swift
+++ b/MVVMKit/Utils/AnyCollectionViewBinder.swift
@@ -58,7 +58,7 @@ public final class AnyCollectionViewBinder<V: CollectionViewViewModel>: Collecti
         box.bind(viewModel: viewModel)
     }
     
-    public func bind(viewModel: V, update viewChange: CollectionViewUpdate?) {
-        box.bind(viewModel: viewModel, update: viewChange)
+    public func bind(viewModel: V, update: CollectionViewUpdate?) {
+        box.bind(viewModel: viewModel, update: update)
     }
 }

--- a/MVVMKit/Utils/AnyCollectionViewBinder.swift
+++ b/MVVMKit/Utils/AnyCollectionViewBinder.swift
@@ -1,0 +1,64 @@
+/*
+ AnyCollectionViewBinder.swift
+ 
+ Copyright (c) 2019 Alfonso Grillo
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+private class AnyCollectionViewBinderBase<V: CollectionViewViewModel>: CollectionViewBinder {
+    func bind(viewModel: V) { }
+    func bind(viewModel: V, update: CollectionViewUpdate?) { }
+}
+
+private final class AnyCollectionViewBinderBox<B: CollectionViewBinder>: AnyCollectionViewBinderBase<B.CustomViewModel> {
+    weak var base: B?
+    
+    init(_ base: B) {
+        self.base = base
+    }
+    
+    override func bind(viewModel: B.CustomViewModel) {
+        base?.bind(viewModel: viewModel)
+    }
+    
+    override func bind(viewModel: B.CustomViewModel, update viewChange: CollectionViewUpdate?) {
+        base?.bind(viewModel: viewModel, update: viewChange)
+    }
+}
+
+/**
+The type erasure of `CollectionViewBinder`.
+- Attention: To avoid memory leak `AnyCollectionViewBinder` has a weak reference to the embedded `CollectionViewBinder`
+*/
+public final class AnyCollectionViewBinder<V: CollectionViewViewModel>: CollectionViewBinder {
+    private let box: AnyCollectionViewBinderBase<V>
+    
+    public init<B: CollectionViewBinder>(_ binder: B) where B.CustomViewModel == V {
+        box = AnyCollectionViewBinderBox(binder)
+    }
+    
+    public func bind(viewModel: V) {
+        box.bind(viewModel: viewModel)
+    }
+    
+    public func bind(viewModel: V, update viewChange: CollectionViewUpdate?) {
+        box.bind(viewModel: viewModel, update: viewChange)
+    }
+}

--- a/MVVMKit/Utils/AnyTableViewBinder.swift
+++ b/MVVMKit/Utils/AnyTableViewBinder.swift
@@ -58,7 +58,7 @@ public final class AnyTableViewBinder<V: TableViewViewModel>: TableViewBinder {
         box.bind(viewModel: viewModel)
     }
     
-    public func bind(viewModel: V, update viewChange: TableViewUpdate?) {
-        box.bind(viewModel: viewModel, update: viewChange)
+    public func bind(viewModel: V, update: TableViewUpdate?) {
+        box.bind(viewModel: viewModel, update: update)
     }
 }

--- a/MVVMKit/Utils/AnyTableViewBinder.swift
+++ b/MVVMKit/Utils/AnyTableViewBinder.swift
@@ -1,0 +1,64 @@
+/*
+ AnyTableViewBinder.swift
+ 
+ Copyright (c) 2019 Alfonso Grillo
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+private class AnyTableViewBinderBase<V: TableViewViewModel>: TableViewBinder {
+    func bind(viewModel: V) { }
+    func bind(viewModel: V, update: TableViewUpdate?) { }
+}
+
+private final class AnyTableViewBinderBox<B: TableViewBinder>: AnyTableViewBinderBase<B.CustomViewModel> {
+    weak var base: B?
+    
+    init(_ base: B) {
+        self.base = base
+    }
+    
+    override func bind(viewModel: B.CustomViewModel) {
+        base?.bind(viewModel: viewModel)
+    }
+    
+    override func bind(viewModel: B.CustomViewModel, update viewChange: TableViewUpdate?) {
+        base?.bind(viewModel: viewModel, update: viewChange)
+    }
+}
+
+/**
+The type erasure of `TableViewBinder`.
+- Attention: To avoid memory leak `AnyTableViewBinder` has a weak reference to the embedded `TableViewBinder`
+*/
+public final class AnyTableViewBinder<V: TableViewViewModel>: TableViewBinder {
+    private let box: AnyTableViewBinderBase<V>
+    
+    public init<B: TableViewBinder>(_ binder: B) where B.CustomViewModel == V {
+        box = AnyTableViewBinderBox(binder)
+    }
+    
+    public func bind(viewModel: V) {
+        box.bind(viewModel: viewModel)
+    }
+    
+    public func bind(viewModel: V, update viewChange: TableViewUpdate?) {
+        box.bind(viewModel: viewModel, update: viewChange)
+    }
+}

--- a/MVVMKit/Utils/WeakReference.swift
+++ b/MVVMKit/Utils/WeakReference.swift
@@ -23,13 +23,8 @@
  */
 
 /// A wrapper of a weak reference.
-public struct WeakReference<T> {
-    private weak var privateRef: AnyObject?
-    
-    public var object: T? {
-        get { return privateRef as? T }
-        set { privateRef = newValue as AnyObject }
-    }
+public struct WeakReference<T: AnyObject> {
+    public weak var object: T?
     
     public init(_ ref: T? = nil) {
         object = ref

--- a/MVVMKit/View Controllers/MVVMCollectionViewController.swift
+++ b/MVVMKit/View Controllers/MVVMCollectionViewController.swift
@@ -45,7 +45,11 @@ open class MVVMCollectionViewController<Model: CollectionViewViewModel>: UIViewC
      The view controller view model
      */
     open var viewModel: Model? {
-        didSet { viewModel?.binder = self }
+        /*
+            The cast isn't really needed here, but for some reason the compiler won't build without it.
+            This issue doesn't seem to affect subclasses.
+         */
+        didSet { viewModel?.binder = AnyCollectionViewBinder(self) as? Model.BinderType }
     }
     
     public var sections: [SectionViewModel] {

--- a/MVVMKit/View Controllers/MVVMTableViewController.swift
+++ b/MVVMKit/View Controllers/MVVMTableViewController.swift
@@ -50,7 +50,11 @@ open class MVVMTableViewController<Model: TableViewViewModel>: UIViewController,
      The view controller view model
      */
     open var viewModel: Model? {
-        didSet { viewModel?.binder = self }
+        /*
+            The cast isn't really needed here, but for some reason the compiler won't build without it.
+            This issue doesn't seem to affect subclasses.
+         */
+        didSet { viewModel?.binder = AnyTableViewBinder<Model>(self) as? Model.BinderType }
     }
     
     public var sections: [SectionViewModel] {


### PR DESCRIPTION
Before this PR `DelegatingViewModel` had binders for which strong type safety was not enforced.
Taking a look to the example project you saw:
```swift
class BasicViewModel: BaseDelegatingViewModel {
    var weakBinder: WeakReference<Binder>?
}
```
Here is the `Binder` protocol:
```swift
public protocol Binder: class {
    func bind(viewModel: ViewModel)
}
```
You notice that strict type safety is not required. You can pass to the `BasicViewModel`'s binder some type conforming to `ViewModel`. But if you do that you'll get a runtime crash because, by default, the binder only know how to bind `BasicViewModel`.

After this PR you can write:
```swift
class BasicViewModel: BaseDelegatingViewModel {
    var binder: AnyBinder<BasicViewModel>?
}
```

Now you are enforced to pass some binder of `BasicViewModel`.
Same type erasure was introduced for table view and collection view binders.