### PR TITLE
Improve DiffableCollectionViewSection supplementary view kinds

### DIFF
--- a/Example/MVVMKit/DiffableCollectionViewController.swift
+++ b/Example/MVVMKit/DiffableCollectionViewController.swift
@@ -39,16 +39,15 @@ class DiffableCollectionViewController: MVVMDiffableCollectionViewController<Dif
     private func setupCollectionView() {
         collectionView.register(SimpleCell.nib, forCellWithReuseIdentifier: SimpleCell.identifier)
         
-        collectionView.register(
-            HeaderFooterReusableView.nib,
-            forSupplementaryViewOfKind: SupplementaryViewKind.header.rawValue,
+        register(
+            nib: HeaderFooterReusableView.nib,
+            forSupplementaryViewOfKind: .header,
             withReuseIdentifier: HeaderFooterReusableView.identifier)
         
-        collectionView.register(
-            HeaderFooterReusableView.nib,
-            forSupplementaryViewOfKind: SupplementaryViewKind.footer.rawValue,
+        register(
+            nib: HeaderFooterReusableView.nib,
+            forSupplementaryViewOfKind: .footer,
             withReuseIdentifier: HeaderFooterReusableView.identifier)
-        
         
         let layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
             switch sectionIndex {

--- a/Example/MVVMKit/DiffableCollectionViewModel.swift
+++ b/Example/MVVMKit/DiffableCollectionViewModel.swift
@@ -77,7 +77,7 @@ class DiffableCollectionViewModel: DiffableCollectionViewViewModel {
             case .main:
                 return [
                     .header: HeaderFooterReusableViewViewModel(text: "Main Header"),
-                    .footer: HeaderFooterReusableViewViewModel(text: "Main Footer"),
+                    .footer: HeaderFooterReusableViewViewModel(text: "Main Footer")
                 ]
             case .second:
                 return [

--- a/Example/MVVMKit/DiffableCollectionViewModel.swift
+++ b/Example/MVVMKit/DiffableCollectionViewModel.swift
@@ -72,17 +72,17 @@ class DiffableCollectionViewModel: DiffableCollectionViewViewModel {
         case main
         case second
         
-        var supplementaryViewViewModels: [String : ReusableViewViewModel] {
+        var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] {
             switch self {
             case .main:
                 return [
-                    SupplementaryViewKind.header.rawValue: HeaderFooterReusableViewViewModel(text: "Main Header"),
-                    SupplementaryViewKind.footer.rawValue: HeaderFooterReusableViewViewModel(text: "Main Footer"),
+                    .header: HeaderFooterReusableViewViewModel(text: "Main Header"),
+                    .footer: HeaderFooterReusableViewViewModel(text: "Main Footer"),
                 ]
             case .second:
                 return [
-                    SupplementaryViewKind.header.rawValue: HeaderFooterReusableViewViewModel(text: "Second Header"),
-                    SupplementaryViewKind.footer.rawValue: HeaderFooterReusableViewViewModel(text: "Second Footer")
+                    .header: HeaderFooterReusableViewViewModel(text: "Second Header"),
+                    .footer: HeaderFooterReusableViewViewModel(text: "Second Footer")
                 ]
             }
         }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 /* Begin PBXBuildFile section */
 		0645A86BEF554EF9F7DA45E96A4F9EF5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8DA2D971384248B54D935BB7012520 /* ViewModel.swift */; };
 		22D295641C3149CDC03002067A22ED1B /* CollectionViewViewModelOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1EC3B958338864EE3D31D56D19FD3E /* CollectionViewViewModelOwner.swift */; };
+		2D96A63D23D38A9A00BBF83B /* MVVMDiffableCollectionViewController+Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D96A63C23D38A9A00BBF83B /* MVVMDiffableCollectionViewController+Register.swift */; };
 		2DB067D923B0B30C0051C480 /* AnyBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB067D823B0B30C0051C480 /* AnyBinder.swift */; };
 		2DB067DB23B0B3710051C480 /* AnyTableViewBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB067DA23B0B3710051C480 /* AnyTableViewBinder.swift */; };
 		2DB067DD23B0B37A0051C480 /* AnyCollectionViewBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB067DC23B0B37A0051C480 /* AnyCollectionViewBinder.swift */; };
@@ -87,6 +88,7 @@
 		267EEE90A5A3EEB674F0A626E92A5382 /* MVVMKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = MVVMKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		27189C6457CC3652BA8F04FA0D59628F /* Pods-MVVMKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-MVVMKit_Example-frameworks.sh"; sourceTree = "<group>"; };
 		272C385A3FA2B20805610BDC8B19D525 /* TableViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewViewModel.swift; sourceTree = "<group>"; };
+		2D96A63C23D38A9A00BBF83B /* MVVMDiffableCollectionViewController+Register.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVVMDiffableCollectionViewController+Register.swift"; sourceTree = "<group>"; };
 		2DB067D823B0B30C0051C480 /* AnyBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyBinder.swift; sourceTree = "<group>"; };
 		2DB067DA23B0B3710051C480 /* AnyTableViewBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTableViewBinder.swift; sourceTree = "<group>"; };
 		2DB067DC23B0B37A0051C480 /* AnyCollectionViewBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCollectionViewBinder.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 				2DB067D823B0B30C0051C480 /* AnyBinder.swift */,
 				2DB067DC23B0B37A0051C480 /* AnyCollectionViewBinder.swift */,
 				2DB067DA23B0B3710051C480 /* AnyTableViewBinder.swift */,
+				2D96A63C23D38A9A00BBF83B /* MVVMDiffableCollectionViewController+Register.swift */,
 				A3778C6553845886F79080FDF8BB2AF6 /* WeakReference.swift */,
 			);
 			name = Utils;
@@ -479,6 +482,7 @@
 			files = (
 				B72C9768931A1008DCE15DDD3D308AB0 /* BaseDelegatingViewModel.swift in Sources */,
 				2DB067DB23B0B3710051C480 /* AnyTableViewBinder.swift in Sources */,
+				2D96A63D23D38A9A00BBF83B /* MVVMDiffableCollectionViewController+Register.swift in Sources */,
 				35A8AE5B3058E690B8F63E7EA2537063 /* Binder.swift in Sources */,
 				66637A5E367A86F184CC1C701B1DB284 /* CollectionViewViewModel.swift in Sources */,
 				22D295641C3149CDC03002067A22ED1B /* CollectionViewViewModelOwner.swift in Sources */,

--- a/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableCollectionViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableCollectionViewViewModel.swift
@@ -40,33 +40,32 @@ public protocol DiffableCollectionViewViewModel: ReferenceViewModel {
     var snapshotPublisher: PassthroughSubject<SnapshotAdapter, Never> { get }
 }
 
-// MARK: - Section
+// MARK: - Section definition
 
 /**
  A protocol describing a section suitable with a UICollectionViewDiffableDataSource
  */
 @available(iOS 13.0, *)
 public protocol DiffableCollectionViewSection: Hashable {
-    associatedtype SupplementaryViewKind: RawRepresentable & Hashable = Never where SupplementaryViewKind.RawValue == String
+    associatedtype SupplementaryViewKind: RawRepresentable & Hashable = None where SupplementaryViewKind.RawValue == String
     
     var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] { get }
 }
 
 @available(iOS 13.0, *)
-public extension DiffableCollectionViewSection where SupplementaryViewKind == Never {
+public extension DiffableCollectionViewSection where SupplementaryViewKind == None {
     var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] {
         [:]
     }
 }
 
-extension Never: RawRepresentable {
+/**
+ A type placeholder for `DiffableCollectionViewSection` without supplementary views
+ */
+public enum None: RawRepresentable, Hashable {
     public typealias RawValue = String
-    public init?(rawValue: Self.RawValue) {
-        nil
-    }
-    public var rawValue: String {
-        String(describing: self)
-    }
+    public init?(rawValue: Self.RawValue) { nil }
+    public var rawValue: String { String(describing: self) }
 }
 
 #endif

--- a/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableCollectionViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableCollectionViewViewModel.swift
@@ -47,13 +47,25 @@ public protocol DiffableCollectionViewViewModel: ReferenceViewModel {
  */
 @available(iOS 13.0, *)
 public protocol DiffableCollectionViewSection: Hashable {
-    var supplementaryViewViewModels: [String: ReusableViewViewModel] { get }
+    associatedtype SupplementaryViewKind: RawRepresentable & Hashable = Never where SupplementaryViewKind.RawValue == String
+    
+    var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] { get }
 }
 
 @available(iOS 13.0, *)
-public extension DiffableCollectionViewSection {
-    var supplementaryViewViewModels: [String: ReusableViewViewModel] {
+public extension DiffableCollectionViewSection where SupplementaryViewKind == Never {
+    var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] {
         [:]
+    }
+}
+
+extension Never: RawRepresentable {
+    public typealias RawValue = String
+    public init?(rawValue: Self.RawValue) {
+        nil
+    }
+    public var rawValue: String {
+        String(describing: self)
     }
 }
 

--- a/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableTableViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableTableViewViewModel.swift
@@ -40,7 +40,7 @@ public protocol DiffableTableViewViewModel: ReferenceViewModel {
     var snapshotPublisher: PassthroughSubject<SnapshotAdapter, Never> { get }
 }
 
-// MARK: - Section
+// MARK: - Section definition
 
 /**
 A protocol describing a section suitable with a UITableViewDiffableDataSource

--- a/MVVMKit/Utils/MVVMDiffableCollectionViewController+Register.swift
+++ b/MVVMKit/Utils/MVVMDiffableCollectionViewController+Register.swift
@@ -1,0 +1,42 @@
+/*
+ MVVMDiffableCollectionViewController+Register.swift
+ 
+ Copyright (c) 2019 Alfonso Grillo
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+@available(iOS 13.0, *)
+public extension MVVMDiffableCollectionViewController {
+    func register(
+        viewClass: AnyClass?,
+        forSupplementaryViewOfKind kind: ViewModelType.SectionType.SupplementaryViewKind,
+        withReuseIdentifier identifier: String) {
+        
+        collectionView.register(viewClass, forSupplementaryViewOfKind: kind.rawValue, withReuseIdentifier: identifier)
+    }
+    
+    func register(
+        nib: UINib?,
+        forSupplementaryViewOfKind kind: ViewModelType.SectionType.SupplementaryViewKind,
+        withReuseIdentifier identifier: String) {
+        
+        collectionView.register(nib, forSupplementaryViewOfKind: kind.rawValue, withReuseIdentifier: identifier)
+    }
+}

--- a/MVVMKit/View Controllers/MVVMDiffableCollectionViewController.swift
+++ b/MVVMKit/View Controllers/MVVMDiffableCollectionViewController.swift
@@ -61,16 +61,16 @@ open class MVVMDiffableCollectionViewController<Model: DiffableCollectionViewVie
             return cell
         }
         
-        dataSource.supplementaryViewProvider = { [weak self] (collectionView, kind, indexPath) in
+        dataSource.supplementaryViewProvider = { [weak self] (collectionView, rawKind, indexPath) in
             guard let self = self else { return nil }
             let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
-            if let viewModel = section.supplementaryViewViewModels[kind] {
-                let reusableView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: viewModel.identifier, for: indexPath)
+            if let kind = Model.SectionType.SupplementaryViewKind(rawValue: rawKind), let viewModel = section.supplementaryViewViewModels[kind] {
+                let reusableView = collectionView.dequeueReusableSupplementaryView(ofKind: rawKind, withReuseIdentifier: viewModel.identifier, for: indexPath)
                 self.configureDelegate(of: reusableView)
                 self.configure(view: reusableView, with: viewModel)
                 return reusableView
             } else {
-                fatalError("No view model found for the supplementary view of kind \(kind)")
+                fatalError("No view model found for the supplementary view of kind \(rawKind)")
             }
         }
     }

--- a/MVVMKit/View Controllers/MVVMDiffableCollectionViewController.swift
+++ b/MVVMKit/View Controllers/MVVMDiffableCollectionViewController.swift
@@ -67,7 +67,7 @@ open class MVVMDiffableCollectionViewController<ViewModelType: DiffableCollectio
         dataSource.supplementaryViewProvider = { [weak self] (collectionView, rawKind, indexPath) in
             guard let self = self else { return nil }
             let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
-            if let kind = Model.SectionType.SupplementaryViewKind(rawValue: rawKind), let viewModel = section.supplementaryViewViewModels[kind] {
+            if let kind = ViewModelType.SectionType.SupplementaryViewKind(rawValue: rawKind), let viewModel = section.supplementaryViewViewModels[kind] {
                 let reusableView = collectionView.dequeueReusableSupplementaryView(ofKind: rawKind, withReuseIdentifier: viewModel.identifier, for: indexPath)
                 self.configureDelegate(of: reusableView)
                 self.configure(view: reusableView, with: viewModel)


### PR DESCRIPTION
Before this PR the definition of `DiffableCollectionViewSection` was the following:

```swift
@available(iOS 13.0, *)
public protocol DiffableCollectionViewSection: Hashable {
    var supplementaryViewViewModels: [String: ReusableViewViewModel] { get }
}
```

When you provided `supplementaryViewViewModels` you had to use `String` as keys of the supplementary view dictionary. In most cases the developers created an enum with a `String` raw value and passed these as Dictionary keys.

With this PR we want to enforce this best practice:
```swift
@available(iOS 13.0, *)
public protocol DiffableCollectionViewSection: Hashable {
    associatedtype SupplementaryViewKind: RawRepresentable & Hashable = Never where SupplementaryViewKind.RawValue == String
    
    var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] { get }
}
```

The developer is now required to provide a`RawRepresentable & Hashable` type to specify the kinds of supplementary views (basically an enum with `String` raw value).

For example you could define:
```swift
enum SupplementaryViewKind: String {
    case header
    case footer
}
```

And then define the diffable section:

```swift
    enum Section: DiffableCollectionViewSection {
        case main
        case second
        
        var supplementaryViewViewModels: [SupplementaryViewKind: ReusableViewViewModel] {
            switch self {
            case .main:
                return [
                    .header: HeaderFooterReusableViewViewModel(text: "Main Header"),
                    .footer: HeaderFooterReusableViewViewModel(text: "Main Footer")
                ]
            case .second:
                return [
                    .header: HeaderFooterReusableViewViewModel(text: "Second Header"),
                    .footer: HeaderFooterReusableViewViewModel(text: "Second Footer")
                ]
            }
        }
    }
```

As you can see the final code is more compact and strong type safety is required.