### PR TITLE
Fix circular reference build error

### DIFF
--- a/MVVMKit/Protocols/View Model/Delegate/Container View Models/CollectionViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/Container View Models/CollectionViewViewModel.swift
@@ -28,7 +28,8 @@ import UIKit
 /**
  The view model for a UICollectionView
  */
-public protocol CollectionViewViewModel: DelegatingViewModel where BinderType == AnyCollectionViewBinder<Self> {
+public protocol CollectionViewViewModel: DelegatingViewModel {
+    associatedtype BinderType: CollectionViewBinder = AnyCollectionViewBinder<Self>
     var sections: [SectionViewModel] { get }
 }
 

--- a/MVVMKit/Protocols/View Model/Delegate/Container View Models/TableViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Delegate/Container View Models/TableViewViewModel.swift
@@ -28,7 +28,8 @@ import UIKit
 /**
  The view model for a UITableView
  */
-public protocol TableViewViewModel: DelegatingViewModel where BinderType == AnyTableViewBinder<Self> {
+public protocol TableViewViewModel: DelegatingViewModel {
+    associatedtype BinderType: TableViewBinder = AnyTableViewBinder<Self>
     var sections: [SectionViewModel] { get }
 }
 


### PR DESCRIPTION
This fix is needed because of the build error from Xcode version 11.4 for CollectionViewViewModel and TableViewViewModel declaration.

`circular reference`

The associated type BinderType redefines new requirements for the DelegatingViewModel associated type and provide the related type-erased binder as default value.