### PR TITLE
Add Compositional Layout utils

### DIFF
--- a/Example/MVVMKit/DiffableCollectionViewController.swift
+++ b/Example/MVVMKit/DiffableCollectionViewController.swift
@@ -30,9 +30,9 @@ class DiffableCollectionViewController: MVVMDiffableCollectionViewController<Dif
         setupCollectionView()
     }
     
-    func bind(viewModel: ViewModel) {
+    override func bind(viewModel: DiffableCollectionViewModel) {
         super.bind(viewModel: viewModel)
-        setupCollectionView()
+        updateLayout(with: viewModel)
     }
     
     private func setupCollectionView() {
@@ -52,19 +52,6 @@ class DiffableCollectionViewController: MVVMDiffableCollectionViewController<Dif
             BadgeReusableView.nib,
             forSupplementaryViewOfKind: SupplementaryViewKind.badge.rawValue,
             withReuseIdentifier: BadgeReusableView.identifier)
-        
-        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, _) -> NSCollectionLayoutSection? in
-            switch sectionIndex {
-            case 0:
-                return self?.listSection(columns: 1)
-            case 1:
-                return self?.listSection(columns: 2)
-            default:
-                return nil
-            }
-        }
-        
-        collectionView.setCollectionViewLayout(layout, animated: false)
     }
 }
 
@@ -74,8 +61,8 @@ extension DiffableCollectionViewController: UISearchBarDelegate {
     }
 }
 
-private extension DiffableCollectionViewController {
-    func listSection(columns: Int = 1) -> NSCollectionLayoutSection {
+private extension NSCollectionLayoutSection {
+    static func listSection(columns: Int = 1) -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .fractionalHeight(1.0))
@@ -117,5 +104,18 @@ private extension DiffableCollectionViewController {
         section.interGroupSpacing = insetValue
         section.contentInsets = .init(top: insetValue, leading: 0, bottom: insetValue, trailing: 0)
         return section
+    }
+}
+
+// MARK: Layout
+
+extension DiffableCollectionViewModel.Section {
+    func sectionLayout(with environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? {
+        switch self {
+        case .main:
+            return .listSection(columns: 1)
+        case .second:
+            return .listSection(columns: 2)
+        }
     }
 }

--- a/Example/MVVMKit/DiffableCollectionViewModel.swift
+++ b/Example/MVVMKit/DiffableCollectionViewModel.swift
@@ -101,7 +101,7 @@ class DiffableCollectionViewModel: DiffableCollectionViewViewModel {
         }
     }
     
-    enum Section: Int, CaseIterable {
+    enum Section: Int, CaseIterable, SectionLayoutConvertible {
         case main = 0
         case second = 1
     }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			dependencies = (
 			);
 			name = SwiftLint;
+			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
@@ -24,6 +25,7 @@
 		0DCCC175F3113EA9929716C85F812F04 /* MVVMDiffableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6376A94C1EF4C4822DC1362F0B79D743 /* MVVMDiffableTableViewController.swift */; };
 		192E130C0595C03E4003431A9C664B74 /* DiffableTableViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1BE89C46F8045BD3F8F8E0E280023E /* DiffableTableViewViewModel.swift */; };
 		1D5F68EA92BDA56BFEF861FC4B1703AB /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D6364AC3271BEB93552CEFBEF972AB /* ViewModel.swift */; };
+		2DA356C22439E1D700DA87F0 /* MVVMDiffableCollectionViewController+CompositionalLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA356C12439E1D700DA87F0 /* MVVMDiffableCollectionViewController+CompositionalLayout.swift */; };
 		36805FC8B1659211B80E2CD5ACDB430B /* WeakReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EACD5AF11419A6EDC8A5D649FD9490 /* WeakReference.swift */; };
 		37C87373EF29B4F2DDA3C2D764794D25 /* Pods-MVVMKit_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C6FD8613AA9C07EA5463DBC72DDD3AD7 /* Pods-MVVMKit_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		44B3F50FFB250796581DE36C71E86FF3 /* MVVMCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E573BFB4FC811167FAE81F77C1FDA48 /* MVVMCollectionViewController.swift */; };
@@ -79,6 +81,7 @@
 		26A4B447D54C663E2BAC6997B4A9DABF /* DelegatingViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DelegatingViewModel.swift; sourceTree = "<group>"; };
 		27189C6457CC3652BA8F04FA0D59628F /* Pods-MVVMKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-MVVMKit_Example-frameworks.sh"; sourceTree = "<group>"; };
 		2910F57EB56EBABD99D7D9385B6F825F /* ViewModelOwner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelOwner.swift; sourceTree = "<group>"; };
+		2DA356C12439E1D700DA87F0 /* MVVMDiffableCollectionViewController+CompositionalLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVVMDiffableCollectionViewController+CompositionalLayout.swift"; sourceTree = "<group>"; };
 		31C20A83A2A360810D8AD7B7D9803ED2 /* SnapshotUpdate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotUpdate.swift; sourceTree = "<group>"; };
 		3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		3AFD2451E8883FF8B05B756DC36604D5 /* CollectionViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionViewViewModel.swift; sourceTree = "<group>"; };
@@ -87,7 +90,7 @@
 		4162C389C8C1F73F038ACCCFA9DF234D /* Pods-MVVMKit_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MVVMKit_Example-Info.plist"; sourceTree = "<group>"; };
 		4A687C4FB7BF38CED5EF82B9FE20C8BB /* MVVMKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MVVMKit-umbrella.h"; sourceTree = "<group>"; };
 		56904ED86092E98EFD44D998D483652D /* CollectionViewViewModelOwner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionViewViewModelOwner.swift; sourceTree = "<group>"; };
-		59C249E899BE4FFEA0819887040457DB /* MVVMKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MVVMKit.framework; path = MVVMKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		59C249E899BE4FFEA0819887040457DB /* MVVMKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MVVMKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B6D55F82CA4EEF0DCBCB822E2B7D208 /* AnyBinder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyBinder.swift; sourceTree = "<group>"; };
 		5FF3BEA2BD0A0319E5D0A9896CABE43E /* SectionViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SectionViewModel.swift; sourceTree = "<group>"; };
 		60D6364AC3271BEB93552CEFBEF972AB /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
@@ -96,7 +99,7 @@
 		66F37C89F5632B99C298B5AF104C2028 /* Pods-MVVMKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MVVMKit_Example.release.xcconfig"; sourceTree = "<group>"; };
 		71D33FA2D8C6B2F3780CFDBED05ACF40 /* Delegator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Delegator.swift; sourceTree = "<group>"; };
 		72ECFA2B07E81F90107650E9B7F4F746 /* MVVMTableViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MVVMTableViewController.swift; sourceTree = "<group>"; };
-		7A7C5A94AB579D03E2C364021E109ED2 /* Pods_MVVMKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_MVVMKit_Example.framework; path = "Pods-MVVMKit_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A7C5A94AB579D03E2C364021E109ED2 /* Pods_MVVMKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MVVMKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E573BFB4FC811167FAE81F77C1FDA48 /* MVVMCollectionViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MVVMCollectionViewController.swift; sourceTree = "<group>"; };
 		82B485E1C5E7C1B2FD0110920F25BCD4 /* MVVMKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MVVMKit-prefix.pch"; sourceTree = "<group>"; };
 		84934B19EBD24287ED6B6BE0434199F3 /* DispatchQueue+.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+.swift"; sourceTree = "<group>"; };
@@ -104,14 +107,14 @@
 		89F85ACF3D78B39506B75103B4694B36 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
 		96CD88DFB43459587535525D6B9C3FAE /* TableViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewViewModel.swift; sourceTree = "<group>"; };
 		9A0124F2A452B2806AE955FD728A2E56 /* Pods-MVVMKit_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-MVVMKit_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A74527150FD97D5359DCA170948BA1FF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		A74527150FD97D5359DCA170948BA1FF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B805D8BAE4F93945036C7B347F9CF90A /* AnyCollectionViewBinder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyCollectionViewBinder.swift; sourceTree = "<group>"; };
 		BA6AEBCAF0DEE680479A7E3A1E2D4EFF /* Binder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Binder.swift; sourceTree = "<group>"; };
 		BE5F6716DFE614C43523A4CD482AEB88 /* Coordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		C5EACD5AF11419A6EDC8A5D649FD9490 /* WeakReference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeakReference.swift; sourceTree = "<group>"; };
 		C6FD8613AA9C07EA5463DBC72DDD3AD7 /* Pods-MVVMKit_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-MVVMKit_Example-umbrella.h"; sourceTree = "<group>"; };
-		CD4958ED6999B6D564B84294D0B4259F /* MVVMKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = MVVMKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		CD4958ED6999B6D564B84294D0B4259F /* MVVMKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = MVVMKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		CE6AF4F6F4AB74EE012D851FEAFC02B6 /* Pods-MVVMKit_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MVVMKit_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		D46E83A807E30014F7B9E36A7CE1CD5B /* TableViewViewModelOwner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewViewModelOwner.swift; sourceTree = "<group>"; };
 		E02492E4ABE045CE4C51AA9DC25A8C9E /* MVVMDiffableCollectionViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MVVMDiffableCollectionViewController.swift; sourceTree = "<group>"; };
@@ -121,7 +124,7 @@
 		E427DF622C8453CE180733AE5CD0939D /* Pods-MVVMKit_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-MVVMKit_Example-dummy.m"; sourceTree = "<group>"; };
 		EA79FD7B0DA2C0F1FCADE98EB94533A6 /* MVVMKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MVVMKit.xcconfig; sourceTree = "<group>"; };
 		EFD7FD7EAC6309BD551035F7E60DCE6E /* DiffableCollectionViewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiffableCollectionViewViewModel.swift; sourceTree = "<group>"; };
-		F477D610A224ECB30A256E7A66191663 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		F477D610A224ECB30A256E7A66191663 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,7 +209,6 @@
 				5FF3BEA2BD0A0319E5D0A9896CABE43E /* SectionViewModel.swift */,
 				96CD88DFB43459587535525D6B9C3FAE /* TableViewViewModel.swift */,
 			);
-			name = "Container View Models";
 			path = "Container View Models";
 			sourceTree = "<group>";
 		};
@@ -218,7 +220,6 @@
 				65A07D7974CF316A66A15A666EFC7351 /* ReusableViewViewModelAdapter.swift */,
 				31C20A83A2A360810D8AD7B7D9803ED2 /* SnapshotUpdate.swift */,
 			);
-			name = "Diffable Container View Models";
 			path = "Diffable Container View Models";
 			sourceTree = "<group>";
 		};
@@ -252,7 +253,6 @@
 			children = (
 				EEA599FE5C15138FF0981CCFB01E55AA /* Support Files */,
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -277,7 +277,6 @@
 				D46E83A807E30014F7B9E36A7CE1CD5B /* TableViewViewModelOwner.swift */,
 				521930961DACC447E89EDCE6696368FF /* Container View Models */,
 			);
-			name = Delegate;
 			path = Delegate;
 			sourceTree = "<group>";
 		};
@@ -288,7 +287,6 @@
 				B9EB6F5B0582C26CFA12FA731218C32D /* Delegate */,
 				5CC1E77EE876A11E3BE8D6003EC8E2EB /* Diffable Container View Models */,
 			);
-			name = "View Model";
 			path = "View Model";
 			sourceTree = "<group>";
 		};
@@ -347,6 +345,7 @@
 				84934B19EBD24287ED6B6BE0434199F3 /* DispatchQueue+.swift */,
 				7E573BFB4FC811167FAE81F77C1FDA48 /* MVVMCollectionViewController.swift */,
 				E02492E4ABE045CE4C51AA9DC25A8C9E /* MVVMDiffableCollectionViewController.swift */,
+				2DA356C12439E1D700DA87F0 /* MVVMDiffableCollectionViewController+CompositionalLayout.swift */,
 				6376A94C1EF4C4822DC1362F0B79D743 /* MVVMDiffableTableViewController.swift */,
 				72ECFA2B07E81F90107650E9B7F4F746 /* MVVMTableViewController.swift */,
 				E12A850CBFF9B168654069C577BEB027 /* UIViewController+MVVM.swift */,
@@ -475,6 +474,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DA356C22439E1D700DA87F0 /* MVVMDiffableCollectionViewController+CompositionalLayout.swift in Sources */,
 				622CA3EB2A64DC231E7BCF9D68373FCD /* AnyBinder.swift in Sources */,
 				7A0E199464C35FF4743D6A7641A80FD4 /* AnyCollectionViewBinder.swift in Sources */,
 				AAEB6AAC90FD1C341E84BB84690D2A42 /* AnyTableViewBinder.swift in Sources */,
@@ -599,8 +599,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableCollectionViewViewModel.swift
+++ b/MVVMKit/Protocols/View Model/Diffable Container View Models/DiffableCollectionViewViewModel.swift
@@ -48,4 +48,11 @@ public extension DiffableCollectionViewViewModel {
     }
 }
 
+// MARK: Compositional layout utils
+
+@available(iOS 13.0, *)
+public protocol SectionLayoutConvertible {
+    func sectionLayout(with environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection?
+}
+
 #endif

--- a/MVVMKit/View Controllers/MVVMDiffableCollectionViewController+CompositionalLayout.swift
+++ b/MVVMKit/View Controllers/MVVMDiffableCollectionViewController+CompositionalLayout.swift
@@ -1,0 +1,33 @@
+/*
+MVVMDiffableCollectionViewController+CompositionalLayout.swift
+
+Copyright (c) 2020 Alfonso Grillo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+@available(iOS 13.0, *)
+public extension MVVMDiffableCollectionViewController where ViewModelType.SectionType: SectionLayoutConvertible {
+    func updateLayout(with viewModel: ViewModelType, animated: Bool = true) {
+        let layout: UICollectionViewCompositionalLayout = .init { [weak self] (index, environment) -> NSCollectionLayoutSection? in
+            self?.dataSource.snapshot().sectionIdentifiers[index].sectionLayout(with: environment)
+        }
+        collectionView.setCollectionViewLayout(layout, animated: animated)
+    }
+}

--- a/MVVMKit/View Controllers/MVVMDiffableCollectionViewController+CompositionalLayout.swift
+++ b/MVVMKit/View Controllers/MVVMDiffableCollectionViewController+CompositionalLayout.swift
@@ -24,10 +24,17 @@ THE SOFTWARE.
 
 @available(iOS 13.0, *)
 public extension MVVMDiffableCollectionViewController where ViewModelType.SectionType: SectionLayoutConvertible {
-    func updateLayout(with viewModel: ViewModelType, animated: Bool = true) {
+    /**
+     When the `SectionType`s conform to `SectionLayoutConvertible` the class `MVVMDiffableCollectionViewController` provides this method, which
+     fully configures the layout of the collection view with an instance of `UICollectionViewCompositionalLayout`.
+     - Note: It is responsibility of the subclass of `MVVMDiffableCollectionViewController` to configure the layout when it is needed.
+     */
+    @discardableResult
+    func updateLayout(with viewModel: ViewModelType, animated: Bool = true) -> UICollectionViewCompositionalLayout {
         let layout: UICollectionViewCompositionalLayout = .init { [weak self] (index, environment) -> NSCollectionLayoutSection? in
             self?.dataSource.snapshot().sectionIdentifiers[index].sectionLayout(with: environment)
         }
         collectionView.setCollectionViewLayout(layout, animated: animated)
+        return layout
     }
 }


### PR DESCRIPTION
Very often we have a mapping between a view model's section instance and a `NSCollectionLayoutSection` instance.

This PR tries to make this association structured:
* introducing the `SectionLayoutConvertible` protocol
* adding a convenience method to `MVVMDiffableCollectionViewController` to setup the compositional layout easily.